### PR TITLE
1412: Nightly build not creating dev version of IG and Core 

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/build-image-and-artifact
         with: 
           repositoryName: SecureApiGateway/secure-api-gateway-core
-          dockerBuildCommands: "make clean docker tag=latest && make clean docker tag=dev"
+          dockerBuildCommands: "make clean docker tag=latest && make clean docker tag=dev env=dev"
           mavenBuildCommands: "mvn -B deploy -DskipTests"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/build-image-and-artifact
         with: 
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk
-          dockerBuildCommands: "make clean docker tag=latest && make clean docker tag=dev"
+          dockerBuildCommands: "make clean docker tag=latest && make clean docker tag=dev env=dev"
           mavenBuildCommands: "mvn -B deploy -DskipTests"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}


### PR DESCRIPTION
As `env=dev` was missing from the docker command, the dev image for `core` and `ig` was not being built in dev mode

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1412