### PR TITLE
1389: Use CI Repo for standardised steps in github workflows

### DIFF
--- a/.github/actions/authentication/action.yaml
+++ b/.github/actions/authentication/action.yaml
@@ -1,12 +1,12 @@
 name: Authentication
 description: Common commands used to auth to services during workflows
 inputs:
-  garKey:
+  gcpKey:
     description: The GCP Json Auth Key
     required: true
   garLocation:
     description: The location of the Google Artifact Registry
-    required: true
+    required: false
 
 runs:
   using: composite
@@ -15,10 +15,11 @@ runs:
     - name: Auth to GCP
       uses: google-github-actions/auth@v2
       with:
-        credentials_json: ${{ inputs.garKey }}
+        credentials_json: ${{ inputs.gcpKey }}
     - name: Set up Cloud SDK
       uses: google-github-actions/setup-gcloud@v2.1.0
     - name: Auth Docker
       shell: bash
+      if: inputs.garLocation != ''
       run: |
         gcloud auth configure-docker ${{ inputs.garLocation }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Call Authentication
         uses: ./.github/actions/authentication
         with: 
-          garKey: ${{ secrets.DEV_GAR_KEY }}
+          gcpKey: ${{ secrets.DEV_GAR_KEY }}
           garLocation: ${{ vars.GAR_LOCATION }}
       # Build Components
       - name: Call build-image-and-artifact for Core

--- a/.github/workflows/reusable-merge.yml
+++ b/.github/workflows/reusable-merge.yml
@@ -43,7 +43,7 @@ jobs:
         uses: ./secure-api-gateway-ci/.github/actions/authentication
         if: env.STEPS_MERGE_AUTHENTICATE == 'true'
         with:
-          garKey: ${{ secrets.DEV_GAR_KEY }}
+          gcpKey: ${{ secrets.DEV_GAR_KEY }}
           garLocation: ${{ env.GAR_LOCATION }}
       # Set Maven Config
       - name: Set Maven Config

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -84,7 +84,7 @@ jobs:
         uses: ./secure-api-gateway-ci/.github/actions/authentication
         if: env.STEPS_PR_AUTHENTICATE == 'true'
         with:
-          garKey: ${{ secrets.DEV_GAR_KEY }}
+          gcpKey: ${{ secrets.DEV_GAR_KEY }}
           garLocation: ${{ env.GAR_LOCATION }}
       # Set Maven Config
       - name: Set Maven Config

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -64,7 +64,7 @@ jobs:
         uses: ./secure-api-gateway-ci/.github/actions/authentication
         if: env.STEPS_RELEASE_AUTHENTICATE == 'true'
         with:
-          garKey: ${{ secrets.DEV_GAR_KEY }}
+          gcpKey: ${{ secrets.DEV_GAR_KEY }}
           garLocation: ${{ env.GAR_LOCATION }}
       # Set Maven Config
       - name: Set Maven Config

--- a/.github/workflows/reusable-slack-notification.yml
+++ b/.github/workflows/reusable-slack-notification.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     secrets:
       garLocation:
-        required: true
+        required: false
       gcpKey:
         required: true
       gcpProject:

--- a/.github/workflows/reusable-slack-notification.yml
+++ b/.github/workflows/reusable-slack-notification.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           path: secure-api-gateway-ci
           repository: SecureApiGateway/secure-api-gateway-ci
-          ref: 1389-reusable-workflow
       # Auth GCP, SDK & Artifact Registry
       - name: Authentication
         uses: ./secure-api-gateway-ci/.github/actions/authentication

--- a/.github/workflows/reusable-slack-notification.yml
+++ b/.github/workflows/reusable-slack-notification.yml
@@ -20,6 +20,7 @@ jobs:
         uses: ./secure-api-gateway-ci/.github/actions/authentication
         with:
           gcpKey: ${{ inputs.gcpKey }}
+          garLocation: ${{ inputs.garLocation }}
       - name: Get Webhook URL from GSM
         run: |
           echo "SLACK_WEBHOOK=$(gcloud --project ${{ inputs.gcpProject }} secrets versions access latest --secret=${{ inputs.gsmSlackWebhookName }})" >> $GITHUB_ENV

--- a/.github/workflows/reusable-slack-notification.yml
+++ b/.github/workflows/reusable-slack-notification.yml
@@ -1,15 +1,32 @@
 name: Merge Notification
 on:
   workflow_call:
+    secrets:
+      garLocation:
+        required: true
+      gcpKey:
+        required: true
+      gcpProject:
+        required: true
+      gsmSlackWebhookName:
+        required: true
 jobs:
   check:
     runs-on: ubuntu-latest
     name: Push Slack Notification
     steps:
+      # Auth GCP, SDK & Artifact Registry
+      - name: Authentication
+        uses: ./secure-api-gateway-ci/.github/actions/authentication
+        with:
+          gcpKey: ${{ inputs.gcpKey }}
+      - name: Get Webhook URL from GSM
+        run: |
+          echo "SLACK_WEBHOOK=$(gcloud --project ${{ inputs.gcpProject }} secrets versions access latest --secret=${{ inputs.gsmSlackWebhookName }})" >> $GITHUB_ENV
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2.3.0
         env:
           SLACK_USERNAME: GitHub Actions - Merge Complete
-          SLACK_WEBHOOK: ${{ secrets.WEBHOOK_SBAT_NOTIFY_SLACK }}
+          SLACK_WEBHOOK: ${{ env.SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}
           MSG_MINIMAL: commit

--- a/.github/workflows/reusable-slack-notification.yml
+++ b/.github/workflows/reusable-slack-notification.yml
@@ -1,14 +1,15 @@
 name: Merge Notification
 on:
   workflow_call:
-    secrets:
+    inputs:
       garLocation:
         required: false
-      gcpKey:
-        required: true
       gcpProject:
         required: true
       gsmSlackWebhookName:
+        required: true
+    secrets:
+      gcpKey:
         required: true
 jobs:
   check:

--- a/.github/workflows/reusable-slack-notification.yml
+++ b/.github/workflows/reusable-slack-notification.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Authentication
         uses: ./secure-api-gateway-ci/.github/actions/authentication
         with:
-          gcpKey: ${{ inputs.gcpKey }}
+          gcpKey: ${{ secrets.gcpKey }}
           garLocation: ${{ inputs.garLocation }}
       # Get Webhook from GSM
       - name: Get Webhook URL from GSM

--- a/.github/workflows/reusable-slack-notification.yml
+++ b/.github/workflows/reusable-slack-notification.yml
@@ -19,15 +19,24 @@ jobs:
     runs-on: ubuntu-latest
     name: Push Slack Notification
     steps:
+      # Checkout Code
+      - name: Checkout CI Repo
+        uses: actions/checkout@v4
+        with:
+          path: secure-api-gateway-ci
+          repository: SecureApiGateway/secure-api-gateway-ci
+          ref: 1389-reusable-workflow
       # Auth GCP, SDK & Artifact Registry
       - name: Authentication
         uses: ./secure-api-gateway-ci/.github/actions/authentication
         with:
           gcpKey: ${{ inputs.gcpKey }}
           garLocation: ${{ inputs.garLocation }}
+      # Get Webhook from GSM
       - name: Get Webhook URL from GSM
         run: |
           echo "SLACK_WEBHOOK=$(gcloud --project ${{ inputs.gcpProject }} secrets versions access latest --secret=${{ inputs.gsmSlackWebhookName }})" >> $GITHUB_ENV
+      # Post Notification
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2.3.0
         env:

--- a/.github/workflows/reusable-slack-notification.yml
+++ b/.github/workflows/reusable-slack-notification.yml
@@ -3,10 +3,13 @@ on:
   workflow_call:
     inputs:
       garLocation:
+        type: string
         required: false
       gcpProject:
+        type: string
         required: true
       gsmSlackWebhookName:
+        type: string
         required: true
     secrets:
       gcpKey:


### PR DESCRIPTION
Allow secret and vars be pushed to slack notification so that reusable workflow can be used in other orgs

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1389