### PR TITLE
1380: Perform code scanning on nightly build

### DIFF
--- a/.github/actions/check-copyright/action.yaml
+++ b/.github/actions/check-copyright/action.yaml
@@ -1,5 +1,5 @@
 name: Check Copyright
-description: Common steps to check the copyright of our components
+description: Common steps to perform a code scan on a components
 inputs:
   checkoutCode:
     description: Wherever or not to checkout the code for the repo

--- a/.github/actions/check-copyright/action.yaml
+++ b/.github/actions/check-copyright/action.yaml
@@ -1,5 +1,5 @@
 name: Check Copyright
-description: Common steps to perform a code scan on a components
+description: Common steps to perform a copyright check in a maven project
 inputs:
   checkoutCode:
     description: Wherever or not to checkout the code for the repo

--- a/.github/actions/code-scanning/action.yaml
+++ b/.github/actions/code-scanning/action.yaml
@@ -1,5 +1,5 @@
 name: Code Scanning
-description: Common steps to build a Maven artifact
+description: Common steps to perform a code scan on a components
 inputs:
   checkoutCode:
     description: Wherever or not to checkout the code for the repo
@@ -28,14 +28,17 @@ runs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3
+      working-directory: ${{ inputs.repositoryName }}
       with:
         languages: ${{ inputs.language }}
     - name: Autobuild
       uses: github/codeql-action/autobuild@v3
+      working-directory: ${{ inputs.repositoryName }}
       env:
         FR_ARTIFACTORY_USER: ${{ inputs.FR_ARTIFACTORY_USER }}
         FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ inputs.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
+      working-directory: ${{ inputs.repositoryName }}
       with:
         category: "/language:${{ inputs.language }}"

--- a/.github/actions/code-scanning/action.yaml
+++ b/.github/actions/code-scanning/action.yaml
@@ -1,0 +1,41 @@
+name: Code Scanning
+description: Common steps to build a Maven artifact
+inputs:
+  checkoutCode:
+    description: Wherever or not to checkout the code for the repo
+    required: true
+  repositoryName:
+    description: The repository name to checkout
+    required: true
+  FR_ARTIFACTORY_USER:
+    description: What user to use to auth to Maven Server
+    required: true
+  FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD:
+    description: What user password to use to auth to Maven Server
+    required: true
+  language:
+    description: The language to use for the scanning
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      if: inputs.checkoutCode == 'true'
+      with: 
+        repository: ${{ inputs.repositoryName }}
+        path: ${{ inputs.repositoryName }}
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ inputs.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+      env:
+        FR_ARTIFACTORY_USER: ${{ inputs.FR_ARTIFACTORY_USER }}
+        FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ inputs.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{ inputs.language }}"

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -20,3 +20,54 @@ jobs:
         with:
           checkoutCode: true
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout CI Code
+        uses: actions/checkout@v4
+      # Auth GCP, SDK & Artifact Registry
+      - name: Call Authentication
+        uses: ./.github/actions/authentication
+        with:
+          gcpKey: ${{ secrets.DEV_GAR_KEY }}
+          garLocation: ${{ vars.GAR_LOCATION }}
+      - name: Call code-scanning on Core
+        uses: ./secure-api-gateway-ci/.github/actions/code-scanning
+        with:
+          checkoutCode: true
+          language: java-kotlin
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          repositoryName: SecureApiGateway/secure-api-gateway-core
+      - name: Call code-scanning on Common
+        uses: ./secure-api-gateway-ci/.github/actions/code-scanning
+        with:
+          checkoutCode: true
+          language: java-kotlin
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-common
+      - name: Call code-scanning on RCS
+        uses: ./secure-api-gateway-ci/.github/actions/code-scanning
+        with:
+          checkoutCode: true
+          language: java-kotlin
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs
+      - name: Call code-scanning on RS
+        uses: ./secure-api-gateway-ci/.github/actions/code-scanning
+        with:
+          checkoutCode: true
+          language: java-kotlin
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rs

--- a/.github/workflows/reusable-code-scanning.yml
+++ b/.github/workflows/reusable-code-scanning.yml
@@ -1,0 +1,44 @@
+name: Release - Build and Deploy
+on:
+  workflow_call:
+    inputs:
+      componentName:
+        description: The component name using the workflow
+        required: true
+        type: string
+      language:
+        description: The language to perform scan against
+        required: true
+        type: string
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+    steps:
+      # Checkout CI Repo
+      - name: Checkout CI Repo
+        uses: actions/checkout@v4
+        with:
+          path: secure-api-gateway-ci
+          repository: SecureApiGateway/secure-api-gateway-ci
+      # Auth GCP, SDK & Artifact Registry
+      - name: Call Authentication
+        uses: ./.github/actions/authentication
+        with:
+          gcpKey: ${{ secrets.DEV_GAR_KEY }}
+          garLocation: ${{ vars.GAR_LOCATION }}
+      - name: Call code-scanning on Core
+        uses: ./secure-api-gateway-ci/.github/actions/code-scanning
+        with:
+          checkoutCode: true
+          language: ${{ inputs.language }}
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          repositoryName: SecureApiGateway/${{ inputs.componentName }}

--- a/.github/workflows/reusable-code-scanning.yml
+++ b/.github/workflows/reusable-code-scanning.yml
@@ -1,4 +1,4 @@
-name: Release - Build and Deploy
+name: Merge - Perform Code Scan
 on:
   workflow_call:
     inputs:
@@ -34,7 +34,7 @@ jobs:
         with:
           gcpKey: ${{ secrets.DEV_GAR_KEY }}
           garLocation: ${{ vars.GAR_LOCATION }}
-      - name: Call code-scanning on Core
+      - name: Call code-scanning on Component
         uses: ./secure-api-gateway-ci/.github/actions/code-scanning
         with:
           checkoutCode: true


### PR DESCRIPTION
- Add in job to nightly checks to perform scans in the required repos
- Create reusable workflow for individual components to call

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1380