### PR TITLE
1380: Perform code scanning on nightly build

### DIFF
--- a/.github/actions/code-scanning/action.yaml
+++ b/.github/actions/code-scanning/action.yaml
@@ -13,7 +13,7 @@ inputs:
   FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD:
     description: What user password to use to auth to Maven Server
     required: true
-  githubAction:
+  actionTrigger:
     description: Action performed will decide what steps to use
     required: true
   javaArchitecture:
@@ -46,7 +46,7 @@ runs:
     # Set Maven Config
     - name: Set Maven Config
       uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
-      if: inputs.githubAction == 'merge'
+      if: inputs.actionTrigger == 'merge'
       with:
         cache: ${{ inputs.cache }}
         javaArchitecture: ${{ inputs.javaArchitecture }}
@@ -58,7 +58,7 @@ runs:
     # Set Maven Config
     - name: Set Maven Config
       uses: ./.github/actions/set-maven-config
-      if: inputs.githubAction == 'nightly'
+      if: inputs.actionTrigger == 'nightly'
       with:
         cache: ${{ inputs.cache }}
         javaArchitecture: ${{ inputs.javaArchitecture }}

--- a/.github/actions/code-scanning/action.yaml
+++ b/.github/actions/code-scanning/action.yaml
@@ -13,6 +13,9 @@ inputs:
   FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD:
     description: What user password to use to auth to Maven Server
     required: true
+  githubAction:
+    description: Action performed will decide what steps to use
+    required: true
   javaArchitecture:
     description: What java architecture to use
     required: true
@@ -43,6 +46,19 @@ runs:
     # Set Maven Config
     - name: Set Maven Config
       uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
+      if: inputs.githubAction == 'merge'
+      with:
+        cache: ${{ inputs.cache }}
+        javaArchitecture: ${{ inputs.javaArchitecture }}
+        javaDistribution: ${{ inputs.javaDistribution }}
+        javaVersion: ${{ inputs.javaVersion }}
+        mavenServerID: ${{ inputs.mavenServerID }}
+        repositoryName: ${{ inputs.repositoryName }}
+        updateMavenServer: false
+    # Set Maven Config
+    - name: Set Maven Config
+      uses: ./.github/actions/set-maven-config
+      if: inputs.githubAction == 'nightly'
       with:
         cache: ${{ inputs.cache }}
         javaArchitecture: ${{ inputs.javaArchitecture }}

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout CI Code
         uses: actions/checkout@v4
       - name: Call code-scanning on Core
-        uses: ./secure-api-gateway-ci/.github/actions/code-scanning
+        uses: ./.github/actions/code-scanning
         with:
           cache: 'maven'
           checkoutCode: true
@@ -47,7 +47,7 @@ jobs:
           mavenServerID: 'forgerock-internal-releases'
           repositoryName: SecureApiGateway/secure-api-gateway-core
       - name: Call code-scanning on Common
-        uses: ./secure-api-gateway-ci/.github/actions/code-scanning
+        uses: ./.github/actions/code-scanning
         with:
           cache: 'maven'
           checkoutCode: true
@@ -60,7 +60,7 @@ jobs:
           mavenServerID: 'maven.forgerock.org-community'
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-common
       - name: Call code-scanning on RCS
-        uses: ./secure-api-gateway-ci/.github/actions/code-scanning
+        uses: ./.github/actions/code-scanning
         with:
           cache: 'maven'
           checkoutCode: true
@@ -73,7 +73,7 @@ jobs:
           mavenServerID: 'maven.forgerock.org-community'
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs
       - name: Call code-scanning on RS
-        uses: ./secure-api-gateway-ci/.github/actions/code-scanning
+        uses: ./.github/actions/code-scanning
         with:
           cache: 'maven'
           checkoutCode: true

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           checkoutCode: true
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs
-  analyze:
-    name: Analyze
+  analyze-core:
+    name: Analyze Core
     runs-on: 'ubuntu-latest'
     timeout-minutes: 360
     permissions:
@@ -47,42 +47,30 @@ jobs:
           language: 'java-kotlin'
           mavenServerID: 'forgerock-internal-releases'
           repositoryName: SecureApiGateway/secure-api-gateway-core
-      - name: Call code-scanning on Common
+  analyze-common:
+    name: Analyze Common
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout CI Code
+        uses: actions/checkout@v4
+      - name: Call code-scanning on Core
         uses: ./.github/actions/code-scanning
         with:
           cache: 'maven'
           checkoutCode: true
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          githubAction: nightly
           javaArchitecture: x64
           javaDistribution: 'zulu'
           javaVersion: '17'
           language: 'java-kotlin'
-          mavenServerID: 'maven.forgerock.org-community'
+          mavenServerID: 'forgerock-internal-releases'
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-common
-      - name: Call code-scanning on RCS
-        uses: ./.github/actions/code-scanning
-        with:
-          cache: 'maven'
-          checkoutCode: true
-          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
-          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-          javaArchitecture: x64
-          javaDistribution: 'zulu'
-          javaVersion: '17'
-          language: 'java-kotlin'
-          mavenServerID: 'maven.forgerock.org-community'
-          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs
-      - name: Call code-scanning on RS
-        uses: ./.github/actions/code-scanning
-        with:
-          cache: 'maven'
-          checkoutCode: true
-          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
-          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-          javaArchitecture: x64
-          javaDistribution: 'zulu'
-          javaVersion: '17'
-          language: 'java-kotlin'
-          mavenServerID: 'maven.forgerock.org-community'
-          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rs

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -40,6 +40,7 @@ jobs:
           checkoutCode: true
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          githubAction: nightly
           javaArchitecture: x64
           javaDistribution: 'zulu'
           javaVersion: '17'

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -40,7 +40,7 @@ jobs:
           checkoutCode: true
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-          githubAction: nightly
+          actionTrigger: nightly
           javaArchitecture: x64
           javaDistribution: 'zulu'
           javaVersion: '17'
@@ -67,7 +67,7 @@ jobs:
           checkoutCode: true
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-          githubAction: nightly
+          actionTrigger: nightly
           javaArchitecture: x64
           javaDistribution: 'zulu'
           javaVersion: '17'
@@ -94,7 +94,7 @@ jobs:
           checkoutCode: true
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-          githubAction: nightly
+          actionTrigger: nightly
           javaArchitecture: x64
           javaDistribution: 'zulu'
           javaVersion: '17'
@@ -121,7 +121,7 @@ jobs:
           checkoutCode: true
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-          githubAction: nightly
+          actionTrigger: nightly
           javaArchitecture: x64
           javaDistribution: 'zulu'
           javaVersion: '17'

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -4,8 +4,8 @@ on:
     - cron: '0 2 * * 1-5' # UTC
   workflow_dispatch:
 jobs:
-  check:
-    name: Check
+  copyright:
+    name: Copyright
     runs-on: ubuntu-latest
     steps:
       - name: Checkout CI Code
@@ -74,3 +74,57 @@ jobs:
           language: 'java-kotlin'
           mavenServerID: 'forgerock-internal-releases'
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-common
+  analyze-rs:
+    name: Analyze RS
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout CI Code
+        uses: actions/checkout@v4
+      - name: Call code-scanning on Core
+        uses: ./.github/actions/code-scanning
+        with:
+          cache: 'maven'
+          checkoutCode: true
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          githubAction: nightly
+          javaArchitecture: x64
+          javaDistribution: 'zulu'
+          javaVersion: '17'
+          language: 'java-kotlin'
+          mavenServerID: 'forgerock-internal-releases'
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rs
+  analyze-rcs:
+    name: Analyze RCS
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout CI Code
+        uses: actions/checkout@v4
+      - name: Call code-scanning on Core
+        uses: ./.github/actions/code-scanning
+        with:
+          cache: 'maven'
+          checkoutCode: true
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          githubAction: nightly
+          javaArchitecture: x64
+          javaDistribution: 'zulu'
+          javaVersion: '17'
+          language: 'java-kotlin'
+          mavenServerID: 'forgerock-internal-releases'
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs

--- a/.github/workflows/reusable-code-scanning.yml
+++ b/.github/workflows/reusable-code-scanning.yml
@@ -49,6 +49,7 @@ jobs:
           checkoutCode: false
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          githubAction: merge
           javaArchitecture: ${{ env.JAVA_ARCHITECTURE }}
           javaDistribution: ${{ env.JAVA_DISTRIBUTION }}
           javaVersion: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/reusable-code-scanning.yml
+++ b/.github/workflows/reusable-code-scanning.yml
@@ -49,7 +49,7 @@ jobs:
           checkoutCode: false
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-          githubAction: merge
+          actionTrigger: merge
           javaArchitecture: ${{ env.JAVA_ARCHITECTURE }}
           javaDistribution: ${{ env.JAVA_DISTRIBUTION }}
           javaVersion: ${{ env.JAVA_VERSION }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ NOTE:This repository is for internal PingID use only, and not designed for custo
 [![Merge - Build and Deploy](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/actions/workflows/merge.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/actions/workflows/merge.yml)
 [![CodeQL](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/actions/workflows/codeql.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/actions/workflows/codeql.yml)
 [![Release - Build, Deploy & Create Release](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/actions/workflows/release.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/actions/workflows/release.yml)
-[![CodeQL](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/actions/workflows/codeql.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-rs/actions/workflows/codeql.yml)
 ### secure-api-gateway-ob-uk-test-data-initializer
 [![Merge - Build and Deploy](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-test-data-initializer/actions/workflows/merge.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-test-data-initializer/actions/workflows/merge.yml)
 [![Release - Build, Deploy & Create Release](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-test-data-initializer/actions/workflows/release.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-ob-uk-test-data-initializer/actions/workflows/release.yml)


### PR DESCRIPTION
Added a `actionTrigger`  to the code scanning steps as was having issues with directories to use when using the action in the nightly checks Vs reusable workflow - depending on the value of `actionTrigger` certain steps will be ran

The code scanning jobs in nightly checks needed to be separated out, due to conflicts of how the tools work for uploading the results. This also means that the scanning jobs run the same time which will overall improve the run time

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1380