### PR TITLE
1437: Create GitHub actions for Test Trusted Directory

### DIFF
--- a/.github/actions/build-artifact/action.yaml
+++ b/.github/actions/build-artifact/action.yaml
@@ -16,6 +16,9 @@ inputs:
   FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD:
     description: What user password to use to auth to Maven Server
     required: true
+  updateMavenServer:
+    description: Wherever or not the maven server should try get updated
+    required: true
 runs:
   using: composite
   steps:
@@ -27,6 +30,7 @@ runs:
         path: ${{ inputs.repositoryName }}
     - name: Get Version
       shell: bash
+      if: inputs.updateMavenServer == 'true'
       run: |
         echo "VERSION=$( cd ${{ inputs.repositoryName }} && mvn help:evaluate -Dexpression=project.version -q -DforceStdout )" >> $GITHUB_ENV
         echo "MAVEN_SERVER_COMMUNITY=maven.forgerock.org-community" >> $GITHUB_ENV
@@ -34,12 +38,13 @@ runs:
         FR_ARTIFACTORY_USER: ${{ inputs.FR_ARTIFACTORY_USER }}
         FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ inputs.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
     - name: Push to community snapshot if version contains snapshot
-      if: contains( env.VERSION, 'SNAPSHOT')
+      if: contains( env.VERSION, 'SNAPSHOT') && inputs.updateMavenServer == true
       shell: bash
       run: |
         echo "MAVEN_SERVER_COMMUNITY=maven.forgerock.org-community-snapshots" >> $GITHUB_ENV
     - name: Set Cache with Community Repository
       uses: actions/setup-java@v4
+      if: inputs.updateMavenServer == 'true'
       with:
         distribution: 'zulu'
         java-version: '17'

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -49,6 +49,7 @@ jobs:
           mavenBuildCommands: "mvn -B deploy --file pom.xml"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          updateMavenServer: true
       - name: Call build-image-and-artifact for RCS
         uses: ./.github/actions/build-image-and-artifact
         with: 

--- a/.github/workflows/reusable-merge.yml
+++ b/.github/workflows/reusable-merge.yml
@@ -85,6 +85,7 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           repositoryName: ${{ inputs.componentName }}
+          updateMavenServer: false
       # Builds Docker Image
       - name: Build Image
         uses: ./secure-api-gateway-ci/.github/actions/build-image

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -138,6 +138,7 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           repositoryName: ${{ inputs.componentName }}
+          updateMavenServer: false
   deploy:
     runs-on: ubuntu-latest
     name: Deploy

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -148,6 +148,7 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           repositoryName: ${{ inputs.componentName }}
+          updateMavenServer: false
       # Build and Push Image to Artifact Registry
       - name: Build and Push Image to Artifact Registry
         uses: ./secure-api-gateway-ci/.github/actions/build-image


### PR DESCRIPTION
The build artifact step would change the maven repo, we don't want this for builds outside of nightly, so add in a condition to stop this happening

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1454