### PR TITLE
1464: Need multiple Maven config files during github workflows

### DIFF
--- a/.github/actions/build-artifact/action.yaml
+++ b/.github/actions/build-artifact/action.yaml
@@ -40,7 +40,7 @@ runs:
     - name: Push to community snapshot if version contains snapshot
       if: contains( env.VERSION, 'SNAPSHOT')
       shell: bash
-      run:
+      run: |
         if [ ${{ inputs.updateMavenServer }} == 'true' ]; then
           echo "MAVEN_SERVER_COMMUNITY=maven.forgerock.org-community-snapshots" >> $GITHUB_ENV
         fi

--- a/.github/workflows/reusable-merge.yml
+++ b/.github/workflows/reusable-merge.yml
@@ -46,7 +46,7 @@ jobs:
           gcpKey: ${{ secrets.DEV_GAR_KEY }}
           garLocation: ${{ env.GAR_LOCATION }}
       # Set Maven Config
-      - name: Set Maven Config
+      - name: Set Maven Build Config
         uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
         if: env.STEPS_MERGE_SET_MAVEN_CONFIG == 'true'
         with:
@@ -75,7 +75,7 @@ jobs:
           repositoryName: ${{ inputs.componentName }}
           updateMavenServer: false
       # Set Maven Config
-      - name: Set Maven Config
+      - name: Set Maven Upload Config
         uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
         if: env.STEPS_MERGE_SET_MAVEN_CONFIG_SECOND == 'true'
         with:
@@ -87,7 +87,7 @@ jobs:
           repositoryName: ${{ inputs.componentName }}
           updateMavenServer: ${{ env.UPDATE_MERGE_MAVEN_SERVER_ID_SECOND }}
       # Upload Maven Artifacts
-      - name: Build Maven Project
+      - name: Upload Maven Artifacts
         uses: ./secure-api-gateway-ci/.github/actions/build-artifact
         if: env.STEPS_MERGE_UPLOAD_MAVEN_PROJECT == 'true'
         with:


### PR DESCRIPTION
Missing | in run command in build artifact, and rename steps in merge workflow

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1464