### PR TITLE
1462: Run a kustomise build command in PR worklow

### DIFF
--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -78,18 +78,18 @@ jobs:
           if grep -q TAG_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
             sed -i -e 's/TAG_REPLACE/'${{ inputs.dockerTag }}'/g' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env
           fi
-          case ${{ inputs.sapigType }} in
-            core)
-              kustomiseDir="core/kustomize/overlay/7.3.0/dev"
-              ;;
-            ob)
-              kustomiseDir="ob/kustomize/overlay/7.3.0/dev"
-              ;;
-            test-trusted-directory)
-              kustomiseDir="test-trusted-directory/kustomize/dev"
-              ;;
-          esac
           if grep -q KUSTOMIZE_DIR_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
+            case ${{ inputs.sapigType }} in
+              core)
+                kustomiseDir="core/kustomize/overlay/7.3.0/dev"
+                ;;
+              ob)
+                kustomiseDir="ob/kustomize/overlay/7.3.0/dev"
+                ;;
+              test-trusted-directory)
+                kustomiseDir="test-trusted-directory/kustomize/dev"
+                ;;
+            esac
             sed -i -e "s|KUSTOMIZE_DIR_REPLACE|$kustomiseDir|g" secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env
           fi
           grep -v '^#' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env >> $GITHUB_ENV


### PR DESCRIPTION
Move case for sapigtype inside the if statement for KUSTOMIZE_DIR_REPLACE as not all PR workflows pass a sapigtype env var

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1462