### PR TITLE
1482: Merging Strategy for Master (v3) -> OB-V4 (V4)

### DIFF
--- a/.github/workflows/merge-branch.yml
+++ b/.github/workflows/merge-branch.yml
@@ -39,21 +39,13 @@ jobs:
         with:
           gcpKey: ${{ secrets.GCP_SECRET_READ }}
           garLocation: ${{ vars.GAR_LOCATION }}
-      - name: Import GPG Key
-        uses: crazy-max/ghaction-import-gpg@v5
-        with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY_BOT }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE_BOT }}
-          workdir: ${{ inputs.componentName }}
       - name: Perform Rebase
         run: |
           cd ${{ inputs.componentName }}
           git config user.name fropenbanking
           git config user.email obst@forgerock.com
           git rebase origin/${{ inputs.sourceBranch }} || { echo "Conflicts found, unable to rebase" && exit 1; }
-          git push --force-with-lease
+          git push -f
       # Get Webhook from GSM
       - name: Get Webhook URL from GSM
         if: failure()


### PR DESCRIPTION
Revert GPG Key 
Use git push -f as bypass rules not working

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1482