### PR TITLE
1488: Update Nightly Build in CI Repo

### DIFF
--- a/.github/actions/build-artifact/action.yaml
+++ b/.github/actions/build-artifact/action.yaml
@@ -1,14 +1,11 @@
 name: Build Artifact
 description: Common steps to build a Maven artifact
 inputs:
+  checkoutBranch:
+    description: What branch of the repo to checkout
+    required: false
   checkoutCode:
     description: Wherever or not to checkout the code for the repo
-    required: true
-  repositoryName:
-    description: The repository name to checkout
-    required: true
-  mavenBuildCommands:
-    description: The maven commands to be ran to product the artifact
     required: true
   FR_ARTIFACTORY_USER:
     description: What user to use to auth to Maven Server
@@ -16,18 +13,44 @@ inputs:
   FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD:
     description: What user password to use to auth to Maven Server
     required: true
+  mavenBuildCommands:
+    description: The maven commands to be ran to product the artifact
+    required: true
+  repositoryName:
+    description: The repository name to checkout
+    required: true
   updateMavenServer:
     description: Wherever or not the maven server should try get updated
     required: true
 runs:
   using: composite
   steps:
-    - name: Checkout Code
+    - name: Determine what Branch of code to check out
+      shell: bash
+      run: |
+        if [ ${{ inputs.checkoutCode }} == 'true' ]; then
+          if [[ "${{ inputs.checkoutBranch }}" ]]; then
+            echo CHECKOUTBRANCHCODE=true >> ${GITHUB_ENV}
+          else
+            echo CHECKOUTMAINCODE=true >> ${GITHUB_ENV}
+          fi
+        else
+          echo CHECKOUTMAINCODE=false >> ${GITHUB_ENV}
+          echo CHECKOUTBRANCHCODE=false >> ${GITHUB_ENV}
+        fi
+    - name: Checkout Main Branch Code
       uses: actions/checkout@v4
-      if: inputs.checkoutCode == 'true'
+      if: env.CHECKOUTMAINCODE == 'true'
       with: 
         repository: ${{ inputs.repositoryName }}
         path: ${{ inputs.repositoryName }}
+    - name: Checkout Branch Code
+      uses: actions/checkout@v4
+      if: env.CHECKOUTBRANCHCODE == 'true'
+      with:
+        repository: ${{ inputs.repositoryName }}
+        path: ${{ inputs.repositoryName }}
+        ref: ${{ inputs.checkoutBranch }}
     - name: Get Version
       shell: bash
       if: inputs.updateMavenServer == 'true'

--- a/.github/actions/build-image-and-artifact/action.yaml
+++ b/.github/actions/build-image-and-artifact/action.yaml
@@ -1,14 +1,11 @@
 name: Build Image and Artifact
 description: Common steps to build a docker image and a maven artifact
 inputs:
-  repositoryName:
-    description: What repository to checkout
-    required: true
+  checkoutBranch:
+    description: What branch of the repo to checkout
+    required: false
   dockerBuildCommands:
     description: What commands to run to build the image
-    required: true
-  mavenBuildCommands:
-    description: Maven commands to be ran to product the artifact
     required: true
   FR_ARTIFACTORY_USER:
     description: What user to use to auth to Maven Server
@@ -16,7 +13,12 @@ inputs:
   FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD:
     description: What user password to use to auth to Maven Server
     required: true
-
+  mavenBuildCommands:
+    description: Maven commands to be ran to product the artifact
+    required: true
+  repositoryName:
+    description: What repository to checkout
+    required: true
 runs:
   using: composite
   steps:

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -1,11 +1,11 @@
 name: Build Image
 description: Common steps to build a docker image
 inputs:
+  checkoutBranch:
+    description: What branch of the repo to checkout
+    required: false
   checkoutCode:
     description: Wherever or not to checkout the code for the repo
-    required: true
-  repositoryName:
-    description: What repository to checkout
     required: true
   dockerBuildCommands:
     description: What commands to run to build the image
@@ -15,6 +15,9 @@ inputs:
     required: true
   FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD:
     description: What user password to use to auth to Maven Server
+    required: true
+  repositoryName:
+    description: What repository to checkout
     required: true
 
 runs:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,74 +16,122 @@ jobs:
         with: 
           gcpKey: ${{ secrets.DEV_GAR_KEY }}
           garLocation: ${{ vars.GAR_LOCATION }}
-      # Build Components
+      # Build V3 Components
       - name: Call build-image-and-artifact for Test Trusted Directory
         uses: ./.github/actions/build-image-and-artifact
         with:
-          repositoryName: SecureApiGateway/secure-api-gateway-test-trusted-directory
           dockerBuildCommands: "make clean docker tag=latest"
-          mavenBuildCommands: "mvn -B deploy -DskipTests"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests"
+          repositoryName: SecureApiGateway/secure-api-gateway-test-trusted-directory
       - name: Call build-image-and-artifact for Core
         uses: ./.github/actions/build-image-and-artifact
         with: 
-          repositoryName: SecureApiGateway/secure-api-gateway-core
           dockerBuildCommands: "make clean docker tag=latest && make clean docker tag=dev env=dev"
-          mavenBuildCommands: "mvn -B deploy -DskipTests"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests"
+          repositoryName: SecureApiGateway/secure-api-gateway-core
       - name: Call build-image-and-artifact for OB
         uses: ./.github/actions/build-image-and-artifact
         with: 
-          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk
           dockerBuildCommands: "make clean docker tag=latest && make clean docker tag=dev env=dev"
-          mavenBuildCommands: "mvn -B deploy -DskipTests"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests"
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk
       - name: Call build-artifact for Common
         uses: ./.github/actions/build-artifact
         with:
           checkoutCode: true
-          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-common
-          mavenBuildCommands: "mvn -B deploy --file pom.xml"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy --file pom.xml"
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-common
           updateMavenServer: false
       - name: Call build-image-and-artifact for RCS
         uses: ./.github/actions/build-image-and-artifact
         with: 
-          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs
           dockerBuildCommands: "make docker tag=latest"
-          mavenBuildCommands: "make verify && mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "make verify && mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip"
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs
       - name: Call build-image-and-artifact for RS
         uses: ./.github/actions/build-image-and-artifact
         with:
-          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rs
           dockerBuildCommands: "make docker tag=latest"
-          mavenBuildCommands: "mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip"
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rs
       - name: Call build-image for Core Functional Tests
         uses: ./.github/actions/build-image
         with:
           checkoutCode: true
-          repositoryName: SecureApiGateway/secure-api-gateway-functional-test-framework
           dockerBuildCommands: "make docker tag=latest"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          repositoryName: SecureApiGateway/secure-api-gateway-functional-test-framework
       - name: Call build-image for OB Functional Tests
         uses: ./.github/actions/build-image
         with:
           checkoutCode: true
-          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-functional-tests
           dockerBuildCommands: "make docker tag=latest"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-functional-tests
+      # Build V4 Components
+      - name: Call build-image-and-artifact for OB V4
+        uses: ./.github/actions/build-image-and-artifact
+        with:
+          checkoutBranch: ob-v4
+          dockerBuildCommands: "make clean docker tag=latest-v4 && make clean docker tag=dev-v4 env=dev"
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests"
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk
+      - name: Call build-artifact for Common V4
+        uses: ./.github/actions/build-artifact
+        with:
+          checkoutBranch: ob-v4
+          checkoutCode: true
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy --file pom.xml"
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-common
+          updateMavenServer: false
+      - name: Call build-image-and-artifact for RCS V4
+        uses: ./.github/actions/build-image-and-artifact
+        with:
+          checkoutBranch: ob-v4
+          dockerBuildCommands: "make docker tag=latest-v4"
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "make verify && mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip"
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs
+      - name: Call build-image-and-artifact for RS V4
+        uses: ./.github/actions/build-image-and-artifact
+        with:
+          checkoutBranch: ob-v4
+          dockerBuildCommands: "make docker tag=latest-v4"
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests -DskipITs -DdockerCompose.skip -Ddockerfile.skip"
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rs
+      - name: Call build-image for OB Functional Tests V4
+        uses: ./.github/actions/build-image
+        with:
+          checkoutBranch: ob-v4
+          checkoutCode: true
+          dockerBuildCommands: "make docker tag=latest-v4"
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-functional-tests
       # Get Webhook from GSM
       - name: Get Webhook URL from GSM
+        if: failure()
         run: |
           echo "SLACK_WEBHOOK=$(gcloud --project ${{ vars.SAPIG_PROJECT }} secrets versions access latest --secret=${{ vars.GSM_SBAT_WEBOOK_NAME }})" >> $GITHUB_ENV
       - name: Slack Notification

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -35,7 +35,8 @@ jobs:
           repositoryName: SecureApiGateway/secure-api-gateway-core
       - name: Call build-image-and-artifact for OB
         uses: ./.github/actions/build-image-and-artifact
-        with: 
+        with:
+          checkoutBranch: master
           dockerBuildCommands: "make clean docker tag=latest && make clean docker tag=dev env=dev"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
@@ -44,6 +45,7 @@ jobs:
       - name: Call build-artifact for Common
         uses: ./.github/actions/build-artifact
         with:
+          checkoutBranch: master
           checkoutCode: true
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
@@ -52,7 +54,8 @@ jobs:
           updateMavenServer: false
       - name: Call build-image-and-artifact for RCS
         uses: ./.github/actions/build-image-and-artifact
-        with: 
+        with:
+          checkoutBranch: master
           dockerBuildCommands: "make docker tag=latest"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
@@ -61,6 +64,7 @@ jobs:
       - name: Call build-image-and-artifact for RS
         uses: ./.github/actions/build-image-and-artifact
         with:
+          checkoutBranch: master
           dockerBuildCommands: "make docker tag=latest"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
@@ -77,6 +81,7 @@ jobs:
       - name: Call build-image for OB Functional Tests
         uses: ./.github/actions/build-image
         with:
+          checkoutBranch: master
           checkoutCode: true
           dockerBuildCommands: "make docker tag=latest"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}


### PR DESCRIPTION
- Amend previous github actions to allow branches to be passed in on checkout
- add logic for if to checkout the main branch or custom branch
- reorder parameters to be alphabetical order


Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1488