### PR TITLE
1490: Slack notification if nightly checks fail

### DIFF
--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -266,22 +266,20 @@ jobs:
     name: Check for failure & Notify
     runs-on: 'ubuntu-latest'
     needs: [copyright, analyze-core,analyze-common,analyze-rs,analyze-rcs,analyze-common-v4,analyze-rs-v4,analyze-rcs-v4]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       # Auth GCP, SDK & Artifact Registry
       - name: Call Authentication
-        if: env.FAILUREINBUILD == 'true'
         uses: ./.github/actions/authentication
         with:
           gcpKey: ${{ secrets.GCP_SECRET_READ }}
           garLocation: ${{ vars.GAR_LOCATION }}
       # Get Webhook from GSM
       - name: Get Webhook URL from GSM
-        if: env.FAILUREINBUILD == 'true'
         run: |
           echo "SLACK_WEBHOOK=$(gcloud --project ${{ vars.SAPIG_PROJECT }} secrets versions access latest --secret=${{ vars.GSM_SBAT_WEBOOK_NAME }})" >> $GITHUB_ENV
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2
-        if: env.FAILUREINBUILD == 'true'
         env:
           MSG_MINIMAL: commit
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -268,6 +268,9 @@ jobs:
     needs: [copyright, analyze-core,analyze-common,analyze-rs,analyze-rcs,analyze-common-v4,analyze-rs-v4,analyze-rcs-v4]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
+      # Checkout CI Repo
+      - name: Checkout CI Code
+        uses: actions/checkout@v4
       # Auth GCP, SDK & Artifact Registry
       - name: Call Authentication
         uses: ./.github/actions/authentication

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -285,7 +285,7 @@ jobs:
         uses: rtCamp/action-slack-notify@v2
         env:
           MSG_MINIMAL: commit
-          SLACK_COLOR: ${{ job.status }}
+          SLACK_COLOR: failure
           SLACK_MESSAGE: Please check the link in the message
           SLACK_TITLE: Nightly Components Checks Failed
           SLACK_USERNAME: GitHub Actions


### PR DESCRIPTION
Further fixes for getting the slack notification

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1490