### PR TITLE
1507: Support making ig-truststore-pem secret optional for core deployment

### DIFF
--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -138,6 +138,8 @@ jobs:
         with:
           checkoutCode: false
           repositoryName: ${{ inputs.componentName }}
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
       # Run Initial Tests
       - name: Run Pre Build Tests
         if: env.STEPS_PR_RUN_INITIAL_TESTS == 'true'


### PR DESCRIPTION
Fix for running copyright check

Need to pass in the FR Artifactory creds to the step

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1507