### PR TITLE
1472: Test Building Core Image from Latest OpenIG

### DIFF
--- a/.github/actions/build-image-and-artifact/action.yaml
+++ b/.github/actions/build-image-and-artifact/action.yaml
@@ -80,6 +80,11 @@ runs:
     - name: Build Core Code + Test + Create Docker Image
       shell: bash
       run: |
+        # What IG Version to use - Template used in POM for Core at this time
+        if grep -q IG_VERSION_REPLACE ${{ inputs.repositoryName }}/pom.xml; then
+          igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.repositoryName }}.env)
+          sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.repositoryName }}/pom.xml
+        fi
         cd ${{ inputs.repositoryName }}
         ${{ inputs.dockerBuildCommands }}
       env:

--- a/.github/workflows/reusable-merge.yml
+++ b/.github/workflows/reusable-merge.yml
@@ -53,6 +53,11 @@ jobs:
               exit 1
             fi
           fi
+          # What IG Version to use - Template used in POM for Core at this time
+          if grep -q IG_VERSION_REPLACE ${{ inputs.componentName }}/pom.xml; then
+            igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env)
+            sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.componentName }}/pom.xml
+          fi
           # What Docker Tag to build
           if grep -q TAG_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
             sed -i -e 's/TAG_REPLACE/'${{ inputs.dockerTag }}'/g' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -78,10 +78,12 @@ jobs:
           # Sapig Type is optional so need to set it as null if not in use
           sapigType=${{ inputs.sapigType || null }}
           # What IG Version to use - Template used in POM for Core at this time
+          ${{ inputs.componentName }}/pom.xml
           if grep -q IG_VERSION_REPLACE ${{ inputs.componentName }}/pom.xml; then
             igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env)
             sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.componentName }}/pom.xml
           fi
+          cat ${{ inputs.componentName }}/pom.xml
           # What Docker Tag to build
           if grep -q TAG_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
             sed -i -e 's/TAG_REPLACE/'${{ inputs.dockerTag }}'/g' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -80,9 +80,9 @@ jobs:
           # Sapig Type is optional so need to set it as null if not in use
           sapigType=${{ inputs.sapigType || null }}
           # What IG Version to use - Template used in POM for Core at this time
-          cat ${{ inputs.componentName }}/pom.xml
           if grep -q IG_VERSION_REPLACE ${{ inputs.componentName }}/pom.xml; then
             igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env)
+            echo $igVersion
             sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.componentName }}/pom.xml
           fi
           cat ${{ inputs.componentName }}/pom.xml

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -27,8 +27,6 @@ jobs:
         with:
           path: secure-api-gateway-ci
           repository: SecureApiGateway/secure-api-gateway-ci
-          # Remove before merging
-          ref: 1472-use-latest-ig-in-sapig
       # Checkout Calling Repo
       - name: Checkout Calling Repo
         uses: actions/checkout@v4
@@ -68,6 +66,8 @@ jobs:
         with:
           path: secure-api-gateway-ci
           repository: SecureApiGateway/secure-api-gateway-ci
+          # Remove before merging
+          ref: 1472-use-latest-ig-in-sapig
       # Checkout Calling Repo
       - name: Checkout Calling Repo
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -82,7 +82,7 @@ jobs:
           # What IG Version to use - Template used in POM for Core at this time
           if grep -q IG_VERSION_REPLACE ${{ inputs.componentName }}/pom.xml; then
             igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env)
-            echo $igVersion
+            echo "DEBUG: $igVersion"
             sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.componentName }}/pom.xml
           fi
           cat ${{ inputs.componentName }}/pom.xml

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -66,8 +66,6 @@ jobs:
         with:
           path: secure-api-gateway-ci
           repository: SecureApiGateway/secure-api-gateway-ci
-          # Remove before merging
-          ref: 1472-use-latest-ig-in-sapig
       # Checkout Calling Repo
       - name: Checkout Calling Repo
         uses: actions/checkout@v4
@@ -81,13 +79,9 @@ jobs:
           sapigType=${{ inputs.sapigType || null }}
           # What IG Version to use - Template used in POM for Core at this time
           if grep -q IG_VERSION_REPLACE ${{ inputs.componentName }}/pom.xml; then
-            ls -la
-            cat secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env
             igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env)
-            echo "DEBUG: $igVersion"
             sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.componentName }}/pom.xml
           fi
-          cat ${{ inputs.componentName }}/pom.xml
           # What Docker Tag to build
           if grep -q TAG_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
             sed -i -e 's/TAG_REPLACE/'${{ inputs.dockerTag }}'/g' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           path: secure-api-gateway-ci
           repository: SecureApiGateway/secure-api-gateway-ci
+          # Remove before merging
+          ref: 1472-use-latest-ig-in-sapig
       # Checkout Calling Repo
       - name: Checkout Calling Repo
         uses: actions/checkout@v4

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -80,7 +80,7 @@ jobs:
           # Sapig Type is optional so need to set it as null if not in use
           sapigType=${{ inputs.sapigType || null }}
           # What IG Version to use - Template used in POM for Core at this time
-          ${{ inputs.componentName }}/pom.xml
+          cat ${{ inputs.componentName }}/pom.xml
           if grep -q IG_VERSION_REPLACE ${{ inputs.componentName }}/pom.xml; then
             igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env)
             sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.componentName }}/pom.xml

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -77,6 +77,11 @@ jobs:
         run: |
           # Sapig Type is optional so need to set it as null if not in use
           sapigType=${{ inputs.sapigType || null }}
+          # What IG Version to use - Template used in POM for Core at this time
+          if grep -q IG_VERSION_REPLACE ${{ inputs.componentName }}/pom.xml; then
+            igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env)
+            sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.componentName }}/pom.xml
+          fi
           # What Docker Tag to build
           if grep -q TAG_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
             sed -i -e 's/TAG_REPLACE/'${{ inputs.dockerTag }}'/g' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -81,6 +81,8 @@ jobs:
           sapigType=${{ inputs.sapigType || null }}
           # What IG Version to use - Template used in POM for Core at this time
           if grep -q IG_VERSION_REPLACE ${{ inputs.componentName }}/pom.xml; then
+            ls -la
+            cat secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env
             igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env)
             echo "DEBUG: $igVersion"
             sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.componentName }}/pom.xml

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -39,6 +39,11 @@ jobs:
       # Prepare Environment
       - name: Prepare Environment
         run: |
+          # What IG Version to use - Template used in POM for Core at this time
+          if grep -q IG_VERSION_REPLACE ${{ inputs.componentName }}/pom.xml; then
+            igVersion=$(sed -n 's/^IG_VERSION=\(.*\)/\1/p' < secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env)
+            sed -i -e 's/IG_VERSION_REPLACE/'$igVersion'/g' ${{ inputs.componentName }}/pom.xml
+          fi
           if grep -q REPO_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
             sed -i -e 's|REPO_REPLACE|'"${{ vars.GAR_RELEASE_REPO }}"'|g' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env
           fi

--- a/component-config/secure-api-gateway-core.env
+++ b/component-config/secure-api-gateway-core.env
@@ -3,6 +3,7 @@ CACHE=maven
 CF_PIPELINE_BRANCH=main
 CF_TRIGGER_NAME=github-actions-trigger-core
 GAR_LOCATION=europe-west4-docker.pkg.dev
+IG_VERSION=2024.6.0
 JAVA_ARCHITECTURE=x64
 JAVA_DISTRIBUTION=zulu
 JAVA_VERSION=17


### PR DESCRIPTION
This PR will allow a place holder to be used in the pom.xml for Core and replace the version with what is in the .env file

The idea being that our day to day stuff will continue working as is with the place holder, but when needed it can be updated with a different value for testing latest IG images

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1472