### PR TITLE
1472: Test Building Core Image from Latest OpenIG

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout CI Code
         uses: actions/checkout@v4
-        with:
-          ref: 1472-use-latest-ig-in-sapig
       # Auth GCP, SDK & Artifact Registry
       - name: Call Authentication
         uses: ./.github/actions/authentication


### PR DESCRIPTION
Remove branch to checkout for CI

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1472