### PR TITLE
1548: Add in pre merge checks stage to PR

### DIFF
--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -285,6 +285,7 @@ jobs:
           javaVersion: ${{ env.JAVA_VERSION }}
       # PR Artifacts Build
       - name: Check for PR Artifacts
+        if: env.STEPS_PR_SET_MAVEN_CONFIG == 'true'
         run: |
           pomVersion=$(cd ${{ inputs.componentName }} && mvn help:evaluate -Dexpression=revision -q -DforceStdout)
           commonBomVersion=$(cd ${{ inputs.componentName }} && mvn help:evaluate -Dexpression=uk.bom.version -q -DforceStdout)

--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -274,6 +274,15 @@ jobs:
             echo "SAPIG_TYPE=${{ inputs.sapigType }}" >> $GITHUB_ENV
           fi
           grep -v '^#' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env >> $GITHUB_ENV
+      # Set Maven Config
+      - name: Set Maven Config
+        uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
+        if: env.STEPS_PR_SET_MAVEN_CONFIG == 'true'
+        with:
+          cache: ${{ env.CACHE }}
+          javaArchitecture: ${{ env.JAVA_ARCHITECTURE }}
+          javaDistribution: ${{ env.JAVA_DISTRIBUTION }}
+          javaVersion: ${{ env.JAVA_VERSION }}
       # PR Artifacts Build
       - name: Check for PR Artifacts
         run: |


### PR DESCRIPTION
- Need to auth maven to be able to perform mvn commands to get versions
- Only want to run the mvn check if its a mvn project, so adding `if: env.STEPS_PR_SET_MAVEN_CONFIG == 'true'` for the step, as you'd only set mvn config if its a mvn project

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1548