### PR TITLE
1525: Add more descriptive comments, and add in mavenArg as a input a…

### DIFF
--- a/.github/workflows/reusable-pr.yml
+++ b/.github/workflows/reusable-pr.yml
@@ -10,6 +10,10 @@ on:
         description: The Tag to be associated with the new docker image (optional)
         required: false
         type: string
+      mavenArg:
+        description: Maven Arguments to pass to the build command (mainly used for jar versions override) (optional)
+        required: false
+        type: string
       sapigType:
         description: The SAPIG Type for the component (optional)
         required: false
@@ -77,11 +81,13 @@ jobs:
         run: |
           # Sapig Type is optional so need to set it as null if not in use
           sapigType=${{ inputs.sapigType || null }}
-          # What Docker Tag to build
+          # Maven Args is optional so need to set itas null if not in use
+          mavenArg=${{ inputs.mavenArg || null }}
+          # Use dockerTag input to specifty what Docker Tag to build, overriding TAG_REPLACE in the .env file
           if grep -q TAG_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
             sed -i -e 's/TAG_REPLACE/'${{ inputs.dockerTag }}'/g' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env
           fi
-          # Kustomize folders can be different based off of what sapig type is being built
+          # Kustomize folders will be different based off of what sapig type is being built, need to use sapigType if not null to declare what folder in needed
           if grep -q KUSTOMIZE_DIR_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
             case $sapigType in
               core)
@@ -96,17 +102,27 @@ jobs:
             esac
             sed -i -e "s|KUSTOMIZE_DIR_REPLACE|$kustomiseDir|g" secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env
           fi
-          # Override snapshot version if artifacts are being uploaded
+          # We are uploading some build artifacts to maven with a [VERSION]-[PR_NUMBER]-SNAPSHOT format, need to override SNAPSHOT_REPLACE in the env file
           if grep -q SNAPSHOT_REPLACE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
             # Create the snapshot version '[VERSION]-[PR_NUMBER]-SNAPSHOT'
+            # Get the current version from the pom.xml file
             pomVersion=$(cd ${{ inputs.componentName }} && mvn help:evaluate -Dexpression=revision -q -DforceStdout)
+            # Remove SNAPSHOT from the retrieved version if it exists
             if [[ "$pomVersion" =~ "-SNAPSHOT" ]]; then
               pomVersion=${pomVersion/-SNAPSHOT/""}
             fi
+            # Build the new version from the retrieved version and docker tag and add snapshot to the end
             pomVersion="$pomVersion-${{ inputs.dockerTag}}-SNAPSHOT"
+            # Override SNAPSHOT_REPLACE in the env file with the built version
             sed -i -e 's/SNAPSHOT_REPLACE/'$pomVersion'/g' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env
             echo STEPS_PR_OUTPUT_SNAPSHOT_VERSION="true" >> $GITHUB_ENV
             echo STEPS_PR_SNAPSHOT_VERSION=$pomVersion >> $GITHUB_ENV
+          fi
+          # If there are maven args specified from the inputs, then we need to override MAVEN_ARG_OVERRIDE in the env file
+          if [[ -n "$mavenArg" ]]; then
+            if grep -q MAVEN_ARG_OVERRIDE secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env; then
+              sed -i -e 's/MAVEN_ARG_OVERRIDE/'mavenArgs=\"-Dopenig.version=${{ inputs.mavenArg }}\"'/g' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env
+            fi
           fi
           # Once all replacements are done, load all the variables in the .env file to github
           grep -v '^#' secure-api-gateway-ci/component-config/${{ inputs.componentName }}.env >> $GITHUB_ENV

--- a/component-config/secure-api-gateway-core.env
+++ b/component-config/secure-api-gateway-core.env
@@ -21,7 +21,7 @@ STEPS_MERGE_SET_MAVEN_CONFIG=true
 STEPS_MERGE_UPLOAD_MAVEN_PROJECT=true
 STEPS_MERGE_UPLOAD_MAVEN_COMMANDS=mvn -B deploy -DskipTests
 STEPS_PR_AUTHENTICATE=true
-STEPS_PR_BUILD_DOCKER_COMMANDS=make clean && make docker tag=TAG_REPLACE setlatest=false env=dev mavenArgs=-Dopenig.version=0.0.1 && make docker tag=TAG_REPLACE-prod setlatest=false MAVEN_ARG_OVERRIDE
+STEPS_PR_BUILD_DOCKER_COMMANDS=make clean && make docker tag=TAG_REPLACE setlatest=false env=dev MAVEN_ARG_OVERRIDE && make docker tag=TAG_REPLACE-prod setlatest=false MAVEN_ARG_OVERRIDE
 STEPS_PR_BUILD_DOCKER_IMAGE=true
 STEPS_PR_BUILD_MAVEN_PROJECT=false
 STEPS_PR_DEPLOY_CHANGES=true

--- a/component-config/secure-api-gateway-core.env
+++ b/component-config/secure-api-gateway-core.env
@@ -21,7 +21,7 @@ STEPS_MERGE_SET_MAVEN_CONFIG=true
 STEPS_MERGE_UPLOAD_MAVEN_PROJECT=true
 STEPS_MERGE_UPLOAD_MAVEN_COMMANDS=mvn -B deploy -DskipTests
 STEPS_PR_AUTHENTICATE=true
-STEPS_PR_BUILD_DOCKER_COMMANDS=make clean && make docker tag=TAG_REPLACE setlatest=false env=dev && make docker tag=TAG_REPLACE-prod setlatest=false
+STEPS_PR_BUILD_DOCKER_COMMANDS=make clean && make docker tag=TAG_REPLACE setlatest=false env=dev mavenArgs=-Dopenig.version=0.0.1 && make docker tag=TAG_REPLACE-prod setlatest=false mavenArgs="-Dopenig.version=0.0.1"
 STEPS_PR_BUILD_DOCKER_IMAGE=true
 STEPS_PR_BUILD_MAVEN_PROJECT=false
 STEPS_PR_DEPLOY_CHANGES=true

--- a/component-config/secure-api-gateway-core.env
+++ b/component-config/secure-api-gateway-core.env
@@ -21,7 +21,7 @@ STEPS_MERGE_SET_MAVEN_CONFIG=true
 STEPS_MERGE_UPLOAD_MAVEN_PROJECT=true
 STEPS_MERGE_UPLOAD_MAVEN_COMMANDS=mvn -B deploy -DskipTests
 STEPS_PR_AUTHENTICATE=true
-STEPS_PR_BUILD_DOCKER_COMMANDS=make clean && make docker tag=TAG_REPLACE setlatest=false env=dev mavenArgs=-Dopenig.version=0.0.1 && make docker tag=TAG_REPLACE-prod setlatest=false mavenArgs="-Dopenig.version=0.0.1"
+STEPS_PR_BUILD_DOCKER_COMMANDS=make clean && make docker tag=TAG_REPLACE setlatest=false env=dev mavenArgs=-Dopenig.version=0.0.1 && make docker tag=TAG_REPLACE-prod setlatest=false MAVEN_ARG_OVERRIDE
 STEPS_PR_BUILD_DOCKER_IMAGE=true
 STEPS_PR_BUILD_MAVEN_PROJECT=false
 STEPS_PR_DEPLOY_CHANGES=true


### PR DESCRIPTION
- Add more descriptive comments,
- Add in `mavenArg` as a input 
- If `mavenArg` isn't null and `MAVEN_ARG_OVERRIDE` exists in the config env file, then we need to override `MAVEN_ARG_OVERRIDE` with the passed in value

NOTE: This will need revisiting as it's setting `mavenArgs=\"-Dopenig.version=${{ inputs.mavenArg }}\"'` by default, where there may be other maven args being passed in future

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1525