### PR TITLE
1576: Amend Latest-Core to use branch version of Core

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Call build-image-and-artifact for Core with Latest IG
         uses: ./.github/actions/build-image-and-artifact
         with:
+          checkoutBranch: ${{ vars.LATEST_CORE_SAPIG_BRANCH }}
           checkoutCode: true
           dockerBuildCommands: make clean && make docker tag=latestig setlatest=false mavenArgs="-Dopenig.version=${{ vars.LATEST_IG_ARTIFACT_VERSION }}" dockerArgs="--build-arg base_image=${{ vars.LATEST_IG_DOCKER_IMAGE }}"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}


### PR DESCRIPTION
Include checkoutBranch in the latest core command to build branch code
Set `LATEST_CORE_SAPIG_BRANCH` to `1556-use-openig-fapi-module`
Can easily set it back to Main, when this branch eventually gets merged

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1576