### PR TITLE
1639: Fix Nightly Check Build

### DIFF
--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Checkout OB Repo
         uses: actions/checkout@v4
         with:
-          path: secure-api-gateway-ob
-          repository: SecureApiGateway/secure-api-gateway-ob
+          path: secure-api-gateway-ob-uk
+          repository: SecureApiGateway/secure-api-gateway-ob-uk
           ref: main
       # Set Maven Config
       - name: Set Maven Config

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -41,6 +41,13 @@ jobs:
           path: secure-api-gateway-ob-uk
           repository: SecureApiGateway/secure-api-gateway-ob-uk
           ref: master
+      # Checkout Core Repo
+      - name: Checkout Core Repo
+        uses: actions/checkout@v4
+        with:
+          path: secure-api-gateway-core
+          repository: SecureApiGateway/secure-api-gateway-core
+          ref: main
       # Set Maven Config
       - name: Set Maven Config
         uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
@@ -58,21 +65,6 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk
-      # Checkout Core Repo
-      - name: Checkout Core Repo
-        uses: actions/checkout@v4
-        with:
-          path: secure-api-gateway-core
-          repository: SecureApiGateway/secure-api-gateway-core
-          ref: main
-      # Set Maven Config
-      - name: Set Maven Config
-        uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
-        with:
-          cache: maven
-          javaArchitecture: x64
-          javaDistribution: zulu
-          javaVersion: 17
       # CORE
       - name: Call check copyright for CORE V3
         uses: ./secure-api-gateway-ci/.github/actions/check-copyright

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           path: secure-api-gateway-ob-uk
           repository: SecureApiGateway/secure-api-gateway-ob-uk
-          ref: main
+          ref: master
       # Set Maven Config
       - name: Set Maven Config
         uses: ./secure-api-gateway-ci/.github/actions/set-maven-config

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -13,14 +13,6 @@ jobs:
         with:
           path: secure-api-gateway-ci
           repository: SecureApiGateway/secure-api-gateway-ci
-      # Set Maven Config
-      - name: Set Maven Config
-        uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
-        with:
-          cache: maven
-          javaArchitecture: x64
-          javaDistribution: zulu
-          javaVersion: 17
       # Common
       - name: Call check copyright for Common V3
         uses: ./secure-api-gateway-ci/.github/actions/check-copyright
@@ -42,6 +34,21 @@ jobs:
           checkoutBranch: master
           checkoutCode: true
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-rcs
+      # Checkout OB Repo
+      - name: Checkout OB Repo
+        uses: actions/checkout@v4
+        with:
+          path: secure-api-gateway-ob
+          repository: SecureApiGateway/secure-api-gateway-ob
+          ref: main
+      # Set Maven Config
+      - name: Set Maven Config
+        uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
+        with:
+          cache: maven
+          javaArchitecture: x64
+          javaDistribution: zulu
+          javaVersion: 17
       # OB
       - name: Call check copyright for OB V3
         uses: ./secure-api-gateway-ci/.github/actions/check-copyright
@@ -56,6 +63,14 @@ jobs:
           path: secure-api-gateway-core
           repository: SecureApiGateway/secure-api-gateway-core
           ref: main
+      # Set Maven Config
+      - name: Set Maven Config
+        uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
+        with:
+          cache: maven
+          javaArchitecture: x64
+          javaDistribution: zulu
+          javaVersion: 17
       # CORE
       - name: Call check copyright for CORE V3
         uses: ./secure-api-gateway-ci/.github/actions/check-copyright

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -13,6 +13,14 @@ jobs:
         with:
           path: secure-api-gateway-ci
           repository: SecureApiGateway/secure-api-gateway-ci
+      # Set Maven Config
+      - name: Set Maven Config
+        uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
+        with:
+          cache: maven
+          javaArchitecture: x64
+          javaDistribution: zulu
+          javaVersion: 17
       # Common
       - name: Call check copyright for Common V3
         uses: ./secure-api-gateway-ci/.github/actions/check-copyright
@@ -48,14 +56,6 @@ jobs:
           path: secure-api-gateway-core
           repository: SecureApiGateway/secure-api-gateway-core
           ref: main
-      # Set Maven Config
-      - name: Set Maven Config
-        uses: ./secure-api-gateway-ci/.github/actions/set-maven-config
-        with:
-          cache: maven
-          javaArchitecture: x64
-          javaDistribution: zulu
-          javaVersion: 17
       # CORE
       - name: Call check copyright for CORE V3
         uses: ./secure-api-gateway-ci/.github/actions/check-copyright

--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -55,6 +55,8 @@ jobs:
         with:
           checkoutBranch: master
           checkoutCode: true
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk
       # Checkout Core Repo
       - name: Checkout Core Repo


### PR DESCRIPTION
Need to adjust when we call the set maven action as OB now requires it with us moving to 2024.11.0 of openIG

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1639