### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/.github/workflows/build-deploy-openig-pr-codebase.yml
+++ b/.github/workflows/build-deploy-openig-pr-codebase.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd openig
           mvn clean install -DskipTests -Popenig-docker,fapi
-      # Build Core and upload image
+      # Build FAPI PEP AS and upload image
       - name: Build Core
         uses: ./.github/actions/build-image-and-artifact
         with:
@@ -60,11 +60,22 @@ jobs:
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           mavenBuildCommands: "mvn -B deploy -DskipTests"
-          repositoryName: SecureApiGateway/secure-api-gateway-core
+          repositoryName: SecureApiGateway/secure-api-gateway-fapi-pep-as
+      # Build FAPI PEP RS Core and upload image
+      - name: Build Core
+        uses: ./.github/actions/build-image-and-artifact
+        with:
+          checkoutBranch: ${{ inputs.sapigBranch }}
+          checkoutCode: true
+          dockerBuildCommands: make docker tag=ga-openig-${{ github.run_number }} dockerArgs="--build-arg base_image=gcr.io/forgerock-io/ig/docker-build:$(docker images --filter 'reference=gcr.io/forgerock-io/ig/docker-build:*fapi' --format '{{.Tag}}')"
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests"
+          repositoryName: SecureApiGateway/secure-api-gateway-fapi-pep-rs-core
       - name: Deploy to Environment
         uses: ./.github/actions/deploy-to-env
         with:
-          argoServiceName: "ig"
+          argoServiceName: "fapiPepAS"
           branchName: ${{ steps.branch-name.outputs.current_branch || null }}
           cfAPIKey: ${{ secrets.CF_API_KEY }}
           cfTriggerName: "github-actions-trigger-core"
@@ -72,7 +83,22 @@ jobs:
           changeBranch: "false"
           dockerTag: "ga-openig-${{ github.run_number }}"
           gitTrigger: pr
-          serviceName: "ig"
+          serviceName: "fapi-pep-as"
+          sapigType: "core"
+          testTrustedDirectoryArgoServiceName: ${{ env.TEST_TRUSTED_DIRECTORY_ARGO_SERVICE_NAME || null }}
+          testTrustedDirectoryServiceName: ${{ env.TEST_TRUSTED_DIRECTORY_SERVICE_NAME || null }}
+      - name: Deploy to Environment
+        uses: ./.github/actions/deploy-to-env
+        with:
+          argoServiceName: "fapiPepRS"
+          branchName: ${{ steps.branch-name.outputs.current_branch || null }}
+          cfAPIKey: ${{ secrets.CF_API_KEY }}
+          cfTriggerName: "github-actions-trigger-core"
+          cfPipelineBranch: "main"
+          changeBranch: "false"
+          dockerTag: "ga-openig-${{ github.run_number }}"
+          gitTrigger: pr
+          serviceName: "fapi-pep-rs"
           sapigType: "core"
           testTrustedDirectoryArgoServiceName: ${{ env.TEST_TRUSTED_DIRECTORY_ARGO_SERVICE_NAME || null }}
           testTrustedDirectoryServiceName: ${{ env.TEST_TRUSTED_DIRECTORY_SERVICE_NAME || null }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -22,18 +22,29 @@ jobs:
           javaArchitecture: x64
           javaDistribution: zulu
           javaVersion: 17
-      # Build Core with Latest IG
-      - name: Call build-image-and-artifact for Core with Latest IG
+      # Build FAPI-PEP-AS with Latest IG
+      - name: Call build-image-and-artifact for FAPI-PEP-AS with Latest IG
         uses: ./.github/actions/build-image-and-artifact
         with:
-          checkoutBranch: ${{ vars.LATEST_CORE_SAPIG_BRANCH }}
+          checkoutBranch: ${{ vars.LATEST_FAPI_PEP_AS_SAPIG_BRANCH }}
           checkoutCode: true
           dockerBuildCommands: make clean && make docker tag=latestig setlatest=false mavenArgs="-Dopenig.version=${{ vars.LATEST_IG_ARTIFACT_VERSION }}" dockerArgs="--build-arg base_image=${{ vars.LATEST_IG_DOCKER_IMAGE }}"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           mavenBuildCommands: "mvn -B deploy -DskipTests"
-          repositoryName: SecureApiGateway/secure-api-gateway-core
-      # Build OB V3 with Latest Core Components
+          repositoryName: SecureApiGateway/secure-api-gateway-fapi-pep-as
+      # Build FAPI-PEP-RS-CORE with Latest IG
+      - name: Call build-image-and-artifact for FAPI-PEP-RS-Core with Latest IG
+        uses: ./.github/actions/build-image-and-artifact
+        with:
+          checkoutBranch: ${{ vars.LATEST_FAPI_PEP_RS_CORE_SAPIG_BRANCH }}
+          checkoutCode: true
+          dockerBuildCommands: make clean && make docker tag=latestig setlatest=false mavenArgs="-Dopenig.version=${{ vars.LATEST_IG_ARTIFACT_VERSION }}" dockerArgs="--build-arg base_image=${{ vars.LATEST_IG_DOCKER_IMAGE }}"
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests"
+          repositoryName: SecureApiGateway/secure-api-gateway-fapi-pep-rs-core
+      # Build OB with Latest Core Components
       - name: Call build-image-and-artifact for OB with latest IG
         uses: ./.github/actions/build-image-and-artifact
         with:
@@ -62,7 +73,7 @@ jobs:
           javaArchitecture: x64
           javaDistribution: zulu
           javaVersion: 17
-      # Build V3 Components
+      # Build Components
       - name: Call build-artifact for Parent
         uses: ./.github/actions/build-artifact
         with:
@@ -81,15 +92,6 @@ jobs:
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           mavenBuildCommands: "mvn -B deploy --file pom.xml"
           repositoryName: SecureApiGateway/secure-api-gateway-ob-uk-common
-      - name: Call build-image-and-artifact for Test Trusted Directory
-        uses: ./.github/actions/build-image-and-artifact
-        with:
-          checkoutCode: true
-          dockerBuildCommands: "make clean docker tag=latest"
-          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
-          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
-          mavenBuildCommands: "mvn -B deploy -DskipTests"
-          repositoryName: SecureApiGateway/secure-api-gateway-test-trusted-directory
       - name: Call build-image-and-artifact for Core
         uses: ./.github/actions/build-image-and-artifact
         with:
@@ -99,6 +101,15 @@ jobs:
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           mavenBuildCommands: "mvn -B deploy -DskipTests"
           repositoryName: SecureApiGateway/secure-api-gateway-core
+      - name: Call build-image-and-artifact for Test Trusted Directory
+        uses: ./.github/actions/build-image-and-artifact
+        with:
+          checkoutCode: true
+          dockerBuildCommands: "make clean docker tag=latest"
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests"
+          repositoryName: SecureApiGateway/secure-api-gateway-test-trusted-directory
       - name: Call build-image-and-artifact for OB
         uses: ./.github/actions/build-image-and-artifact
         with:

--- a/.github/workflows/test-openig-nightly-core.yml
+++ b/.github/workflows/test-openig-nightly-core.yml
@@ -21,17 +21,28 @@ jobs:
           javaArchitecture: x64
           javaDistribution: zulu
           javaVersion: 17
-      # Build Core with Latest IG
-      - name: Call build-image-and-artifact for Core with Latest IG
+      # Build FAPI-PEP-AS with Latest IG
+      - name: Call build-image-and-artifact for FAPI-PEP-AS with Latest IG
         uses: ./.github/actions/build-image-and-artifact
         with:
-          checkoutBranch: ${{ vars.LATEST_CORE_SAPIG_BRANCH }}
+          checkoutBranch: ${{ vars.LATEST_FAPI_PEP_AS_SAPIG_BRANCH }}
           checkoutCode: true
           dockerBuildCommands: make clean && make docker tag=latestig setlatest=false mavenArgs="-Dopenig.version=${{ vars.LATEST_IG_ARTIFACT_VERSION }}" dockerArgs="--build-arg base_image=${{ vars.LATEST_IG_DOCKER_IMAGE }}"
           FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
           FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
           mavenBuildCommands: "mvn -B deploy -DskipTests"
-          repositoryName: SecureApiGateway/secure-api-gateway-core
+          repositoryName: SecureApiGateway/secure-api-gateway-fapi-pep-as
+      # Build FAPI-PEP-RS-CORE with Latest IG
+      - name: Call build-image-and-artifact for FAPI-PEP-RS-Core with Latest IG
+        uses: ./.github/actions/build-image-and-artifact
+        with:
+          checkoutBranch: ${{ vars.LATEST_FAPI_PEP_RS_CORE_SAPIG_BRANCH }}
+          checkoutCode: true
+          dockerBuildCommands: make clean && make docker tag=latestig setlatest=false mavenArgs="-Dopenig.version=${{ vars.LATEST_IG_ARTIFACT_VERSION }}" dockerArgs="--build-arg base_image=${{ vars.LATEST_IG_DOCKER_IMAGE }}"
+          FR_ARTIFACTORY_USER: ${{ secrets.FR_ARTIFACTORY_USER }}
+          FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD: ${{ secrets.FR_ARTIFACTORY_USER_ENCRYPTED_PASSWORD }}
+          mavenBuildCommands: "mvn -B deploy -DskipTests"
+          repositoryName: SecureApiGateway/secure-api-gateway-fapi-pep-rs-core
   deploy:
     name: Deploy
     runs-on: ubuntu-22.04
@@ -64,7 +75,8 @@ jobs:
       # Delete Current IG Pod from Cluster
       - name: Delete Current IG Pod
         run: |
-          kubectl delete deployment ${{ vars.OPENIG_NIGHTLY_CORE_POD }} -n ${{ vars.OPENIG_NIGHTLY_CORE_NAMESPACE }} --wait=true
+          kubectl delete deployment ${{ vars.OPENIG_NIGHTLY_FAPI_PEP_AS_POD }} -n ${{ vars.OPENIG_NIGHTLYCORE_NAMESPACE }} --wait=true
+          kubectl delete deployment ${{ vars.OPENIG_NIGHTLY_FAPI_PEP_RS_CORE_POD }} -n ${{ vars.OPENIG_NIGHTLYCORE_NAMESPACE }} --wait=true
       # Remove IP from Whitelist - to be added in
       - name: Remove Build Runner IP from Whitelist
         run: |

--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ NOTE:This repository is for internal PingID use only, and not designed for custo
 ### sapig-openbanking-uk-developer-envs
 [![Release - Build, Deploy & Create Release](https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/actions/workflows/release.yml/badge.svg)](https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/actions/workflows/release.yml)
 [![Check Json Order](https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/actions/workflows/merge.yml/badge.svg)](https://github.com/SecureApiGateway/sapig-openbanking-uk-developer-envs/actions/workflows/merge.yml)
-### secure-api-gateway-core
-[![Merge - Build and Deploy](https://github.com/SecureApiGateway/secure-api-gateway-core/actions/workflows/merge.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-core/actions/workflows/merge.yml)
-[![Merge - Perform Code Scan](https://github.com/SecureApiGateway/secure-api-gateway-core/actions/workflows/codeql.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-core/actions/workflows/codeql.yml)
-[![Release - Build, Deploy & Create Release](https://github.com/SecureApiGateway/secure-api-gateway-core/actions/workflows/release.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-core/actions/workflows/release.yml)
+### secure-api-gateway-fapi-pep-as
+[![Merge - Build and Deploy](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as/actions/workflows/merge.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as/actions/workflows/merge.yml)
+[![Merge - Perform Code Scan](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as/actions/workflows/codeql.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as/actions/workflows/codeql.yml)
+[![Release - Build, Deploy & Create Release](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as/actions/workflows/release.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as/actions/workflows/release.yml)
+### secure-api-gateway-fapi-pep-rs-core
+[![Merge - Build and Deploy](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/actions/workflows/merge.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/actions/workflows/merge.yml)
+[![Merge - Perform Code Scan](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/actions/workflows/codeql.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/actions/workflows/codeql.yml)
+[![Release - Build, Deploy & Create Release](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/actions/workflows/release.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-rs-core/actions/workflows/release.yml)
 ### secure-api-gateway-functional-test-framework
 [![Merge - Build and Deploy](https://github.com/SecureApiGateway/secure-api-gateway-functional-test-framework/actions/workflows/merge.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-functional-test-framework/actions/workflows/merge.yml)
 [![Release - Build, Deploy & Create Release](https://github.com/SecureApiGateway/secure-api-gateway-functional-test-framework/actions/workflows/release.yml/badge.svg)](https://github.com/SecureApiGateway/secure-api-gateway-functional-test-framework/actions/workflows/release.yml)
@@ -88,7 +92,7 @@ jobs:
     uses: SecureApiGateway/secure-api-gateway-ci/.github/workflows/reusable-pr.yml@main
     secrets: inherit
     with:
-      componentName: secure-api-gateway-core
+      componentName: secure-api-gateway-fapi-pep-as
       dockerTag: pr-${{ github.event.number }}
 ```
 
@@ -99,7 +103,7 @@ What may differ from repo to repo is
 
 There is no versioning within this part of the workflow by design. This is so that within the secure-api-gateway-ci repo, there is a `component-config` folder, which has many `.env` files. The reusable workflows use the `componentName` passed from the calling workflow, to retrieve the corresponding .env file within the folder. The `.env` files will have various different variables within, such as `JAVA_DISTRIBUTION`,`SERVICE_NAME` and `SAPIG_TYPE`. There are also `STEPS_PR_*` and `STEPS_MERGE_*` variables which control which actions in the reusable workflow are ran. 
 
-For example using our `Core` repo again, we need to build a docker image, and build the maven project os that we get artifacts produced. Within the `.env` file we have `STEPS_MERGE_BUILD_DOCKER_IMAGE`,`STEPS_MERGE_BUILD_MAVEN_PROJECT` set to `true`. We don't want functional tests to run so `STEPS_MERGE_RUN_FUNCTIONAL_TESTS` is set to `false`. 
+For example using our `FAPI-PEP-AS` repo again, we need to build a docker image, and build the maven project os that we get artifacts produced. Within the `.env` file we have `STEPS_MERGE_BUILD_DOCKER_IMAGE`,`STEPS_MERGE_BUILD_MAVEN_PROJECT` set to `true`. We don't want functional tests to run so `STEPS_MERGE_RUN_FUNCTIONAL_TESTS` is set to `false`. 
 
 The main improvement for this way of structuring our workflows, is that if a change is needed to go to a newer version of Java for example, instead of checking out each individual component repository which uses java, making the change, creating a PR, getting the PR approved, and finally merging, we can create one PR with in the CI repo, with one PR.
 


### PR DESCRIPTION
Update README.md
Update nightly build to build fapi-pep-as & fapi-pep-rs-core
Update Build & Test  Latest OpenIG in Core to include fapi-pep-as & fapi-pep-rs-core
Update OpenIG PR build to build both fapi-pep-as and fapi-pep-rs with the pr version of openIG

Issue: https://github.com/secureapigateway/secureapigateway/issues#zenhub