### PR TITLE
1659: V4 Functional Tests not being ran on PR

### DIFF
--- a/.github/actions/run-functional-tests/action.yaml
+++ b/.github/actions/run-functional-tests/action.yaml
@@ -50,17 +50,10 @@ runs:
             echo "cfPipelineBranch=${{ inputs.cfPipelineBranch }}" >> ${GITHUB_ENV}
           fi        
         fi
-        # If version contains a ',' then its likely come from a GitHub build and we want to remove it
-        if [[ "${{ inputs.testsVersion }}" == *","* ]]; then
-          updatedVersion=$(echo "${{ inputs.testsVersion }}" | sed "s/,/ /")
-          echo "version=$updatedVersion" >> ${GITHUB_ENV}
-        else
-          echo "version=${{ inputs.testsVersion }}" >> ${GITHUB_ENV}
-        fi
     - name: 'Run Functional Tests'
       uses: codefresh-io/codefresh-pipeline-runner@master
       with:
-        args: '-v IMAGE_REPO=securebanking/${{ inputs.serviceName }} -v TAG=${{ inputs.dockerTag }} -v TEST_TASK=${{ env.version }} -v BRANCH=${{ env.cfPipelineBranch }}'
+        args: '-v IMAGE_REPO=securebanking/${{ inputs.serviceName }} -v TAG=${{ inputs.dockerTag }} -v TEST_TASK=${{ inputs.version }} -v BRANCH=${{ env.cfPipelineBranch }}'
       env:
         PIPELINE_NAME: ${{ env.cfPipelineName }}
         CF_API_KEY: ${{ inputs.cfAPIKey }}


### PR DESCRIPTION
 The following test task version is still being ignored when passed to codefresh, move the condition into the codefresh pipeline

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1659