### PR TITLE
OPENIG-10198 Exclude CodeFresh trigger name for FAPI tests

### DIFF
--- a/.github/actions/run-functional-tests/action.yaml
+++ b/.github/actions/run-functional-tests/action.yaml
@@ -12,7 +12,7 @@ inputs:
     required: true
   cfTriggerName:
     description: The name of the trigger in Codefresh pipeline to use
-    required: true
+    required: false
   cfPipelineName:
     description: The Pipeline in codefresh that is being ran
     required: true

--- a/component-config/openig.env
+++ b/component-config/openig.env
@@ -1,6 +1,6 @@
 CF_PIPELINE_BRANCH=main
 CF_PIPELINE_NAME=SAPIG-devenv/dev-cdk-core-functional-tests
-CF_TRIGGER_NAME=github-actions-trigger-functionaltest
+CF_TRIGGER_NAME=
 DOCKER_BUILD_PATH=openig/openig-fapi-tests/functional
 GAR_LOCATION=europe-west4-docker.pkg.dev
 SAPIG_TYPE=core


### PR DESCRIPTION
- Current setup requires CodeFresh trigger which is used to authenticate into [secure-api-gateway-functional-test-framework](https://github.com/SecureApiGateway/secure-api-gateway-functional-test-framework) legacy tests repository to obtain lats committer and commit message
- as tests has been migrated into openig repo, we need extra credentials to authenticate to this private repository
- this change will exclude trigger from running pipeline as it is an optional parameter
  - advantage: we don't need to ask RE for permission to the openig repository 
  - disadvantage: we will lost info about last committer and commit message into CodeFresh as is possible to see on picture bellow
<img width="1953" height="473" alt="Screenshot 2026-04-03 at 15 46 28" src="https://github.com/user-attachments/assets/765a4405-0315-4883-92db-d9dd2e237f2f" />